### PR TITLE
Making FakeKijiClient publicly accessible with test-jar and public const...

### DIFF
--- a/kiji-rest/pom.xml
+++ b/kiji-rest/pom.xml
@@ -240,6 +240,13 @@
             </manifest>
           </archive>
         </configuration>
+      <executions>
+          <execution>
+              <goals>
+                  <goal>test-jar</goal>
+              </goals>
+          </execution>
+      </executions>
       </plugin>
 
       <plugin>

--- a/kiji-rest/src/main/java/org/kiji/rest/representations/KijiRestRow.java
+++ b/kiji-rest/src/main/java/org/kiji/rest/representations/KijiRestRow.java
@@ -99,4 +99,12 @@ public class KijiRestRow {
   public List<KijiRestCell> getCells() {
     return mKijiCells;
   }
+
+  public static KijiRestRow newBlankRow(KijiRestRow row) {
+    KijiRestRow blankRow = new KijiRestRow();
+    blankRow.mHumanReadableEntityId = row.getEntityId();
+    blankRow.mHBaseRowKey = row.getRowKey();
+    blankRow.mKijiCells = Lists.newArrayList();
+    return blankRow;
+  }
 }

--- a/kiji-rest/src/test/java/org/kiji/rest/FakeKijiClient.java
+++ b/kiji-rest/src/test/java/org/kiji/rest/FakeKijiClient.java
@@ -35,7 +35,7 @@ import org.kiji.schema.KijiURI;
 public class FakeKijiClient implements KijiClient {
   private final Kiji mKiji;
 
-  FakeKijiClient(Kiji kiji) {
+  public FakeKijiClient(Kiji kiji) {
     mKiji = kiji;
   }
 


### PR DESCRIPTION
...ructor

Don't actually merge this, please.
Here, I'm making the FakeKijiClient publicly accessible so that it can be used to load fixture data into a testing instance of HBase.
